### PR TITLE
Rename DeviceInfo to DeviceSpecs to remove conflict

### DIFF
--- a/src/weight/WeightDetailPage.qml
+++ b/src/weight/WeightDetailPage.qml
@@ -75,9 +75,9 @@ Item {
                 id: weightSelector
                 anchors {
                     left: parent.left
-                    leftMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+                    leftMargin: DeviceSpecs.hasRoundScreen ? Dims.w(5) : 0
                     right: parent.right
-                    rightMargin: DeviceInfo.hasRoundScreen ? Dims.w(5) : 0
+                    rightMargin: DeviceSpecs.hasRoundScreen ? Dims.w(5) : 0
                     verticalCenter: parent.verticalCenter
                 }
                 height: parent.height*0.6


### PR DESCRIPTION
This renames the DeviceInfo QML class in org.asteroid.utils to DeviceSpecs to avoid a conflict with an unrelated DeviceInfo class defined in org.nemomobile.systemsettings.

This fixes https://github.com/AsteroidOS/qml-asteroid/issues/56